### PR TITLE
server/locks_controller: add API endpoint for listing current locks at /api/locks

### DIFF
--- a/server/locks_controller.go
+++ b/server/locks_controller.go
@@ -30,12 +30,12 @@ type LocksController struct {
 	DeleteLockCommand  events.DeleteLockCommand
 }
 
-// GetLocksResponse is returned to requests against GetLocks at /api/locks with the GET method. It returns a mapping of PRs to locks held by those PRs
+// GetLocksResponse is returned to requests against GetLocks at /api/locks with the GET method. It contains a lock data object for each lock held by atlantis
 type GetLocksResponse struct {
 	Result []LockData
 }
 
-// LockData contains information about the lock, including which PR is holding the lock
+// LockData contains information about the lock, including the lock ID and which PR is holding the lock
 type LockData struct {
 	PullRequestURL string
 	LockID         string

--- a/server/locks_controller.go
+++ b/server/locks_controller.go
@@ -37,17 +37,11 @@ func (l *LocksController) GetLocks() (map[string][]string, error) {
 		return nil, err
 	}
 	for key, lock := range locks {
-		if err != nil {
-			return nil, err
-		}
 		if val, ok := response[lock.Pull.URL]; ok {
 			response[lock.Pull.URL] = append(val, key)
 		} else {
 			response[lock.Pull.URL] = []string{key}
 		}
-	}
-	if err != nil {
-		return nil, err
 	}
 	return response, nil
 }

--- a/server/locks_controller.go
+++ b/server/locks_controller.go
@@ -59,6 +59,7 @@ func (l *LocksController) GetLock(w http.ResponseWriter, r *http.Request) {
 		l.respond(w, logging.Warn, http.StatusBadRequest, "No lock id in request")
 		return
 	}
+
 	idUnencoded, err := url.QueryUnescape(id)
 	if err != nil {
 		l.respond(w, logging.Warn, http.StatusBadRequest, "Invalid lock id: %s", err)

--- a/server/locks_controller_test.go
+++ b/server/locks_controller_test.go
@@ -94,8 +94,7 @@ func TestGetLocks_Success(t *testing.T) {
 	testMap := response.Result[0]
 	expectedVal := "url"
 	Assert(t, testMap.PullRequestURL == expectedVal, "expected lock map ID to equal %s, was %s", expectedVal, testMap.PullRequestURL)
-	Assert(t, len(testMap.LockIDs) == 1, "expected single Lock ID in GetLocks response, was instead length %i", len(testMap.LockIDs))
-	Assert(t, testMap.LockIDs[0] == "test", "expected lock map ID to equal %s, was %s", "test", testMap.LockIDs[0])
+	Assert(t, testMap.LockID == "test", "expected lock map ID to equal %s, was %s", "test", testMap.LockID)
 }
 
 func TestGetLocks_MultipleSuccess(t *testing.T) {
@@ -126,25 +125,15 @@ func TestGetLocks_MultipleSuccess(t *testing.T) {
 	var response server.GetLocksResponse
 	err = json.Unmarshal(body, &response)
 	Ok(t, err)
-	Assert(t, len(response.Result) == 2, "expected map with two entries from GetLocks, was instead length %i", len(response.Result))
+	Assert(t, len(response.Result) == 3, "expected map with three entries from GetLocks, was instead length %i", len(response.Result))
 	for _, lockMap := range response.Result {
 		if lockMap.PullRequestURL == "url" {
-			expectedLocks := 2
-			Assert(t, len(lockMap.LockIDs) == expectedLocks, "expected PR at %s to have %s locks, only returned %s", lockMap.PullRequestURL, expectedLocks, len(lockMap.LockIDs))
-			if lockMap.LockIDs[0] == "testTwo" {
-				expectedLockID := "test"
-				Assert(t, lockMap.LockIDs[1] == expectedLockID, "expected PR at %s to have lock ID %s but found %s instead", lockMap.PullRequestURL, lockMap.LockIDs[0], expectedLockID)
-			} else if lockMap.LockIDs[0] == "test" {
-				expectedLockID := "testTwo"
-				Assert(t, lockMap.LockIDs[1] == expectedLockID, "expected PR at %s to have lock ID %s but found %s instead", lockMap.PullRequestURL, lockMap.LockIDs[0], expectedLockID)
-			} else {
-				Assert(t, false, "Found PR with unexpected lock ID - %s", lockMap.LockIDs[0])
+			if lockMap.LockID != "testTwo" && lockMap.LockID != "test" {
+				Assert(t, false, "unexpected lock ID - found lock with url %s and ID %s", lockMap.PullRequestURL, lockMap.LockID)
 			}
 		} else if lockMap.PullRequestURL == "urlTwo" {
-			expectedLocks := 1
-			Assert(t, len(lockMap.LockIDs) == expectedLocks, "expected PR at %s to have %s locks, only returned %s", lockMap.PullRequestURL, expectedLocks, len(lockMap.LockIDs))
 			expectedLockID := "testThree"
-			Assert(t, lockMap.LockIDs[0] == expectedLockID, "expected PR at %s to have lock ID %s but found %s instead", lockMap.PullRequestURL, lockMap.LockIDs[0], expectedLockID)
+			Assert(t, lockMap.LockID == expectedLockID, "expected PR at %s to have lock ID %s but found %s instead", lockMap.PullRequestURL, lockMap.LockID, expectedLockID)
 		} else {
 			Assert(t, false, "Found PR with unexpected URL - %s", lockMap.PullRequestURL)
 		}

--- a/server/locks_controller_test.go
+++ b/server/locks_controller_test.go
@@ -59,7 +59,7 @@ func TestGetLocks_None(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/api/locks", bytes.NewBuffer(nil))
 	w := httptest.NewRecorder()
 	lc.GetLocks(w, req)
-	Assert(t, w.Code == 200, "expected error from GetLocks to be non nil")
+	Assert(t, w.Code == 200, "expected successful status code from GetLocks but got %s", w.Code)
 	body, err := ioutil.ReadAll(w.Result().Body)
 	Ok(t, err)
 	var response server.GetLocksResponse
@@ -84,7 +84,7 @@ func TestGetLocks_Success(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/api/locks", bytes.NewBuffer(nil))
 	w := httptest.NewRecorder()
 	lc.GetLocks(w, req)
-	Assert(t, w.Code == 200, "expected error from GetLocks to be non nil")
+	Assert(t, w.Code == 200, "expected successful status code from GetLocks but got %s", w.Code)
 	body, err := ioutil.ReadAll(w.Result().Body)
 	Ok(t, err)
 	var response server.GetLocksResponse
@@ -120,7 +120,7 @@ func TestGetLocks_MultipleSuccess(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/api/locks", bytes.NewBuffer(nil))
 	w := httptest.NewRecorder()
 	lc.GetLocks(w, req)
-	Assert(t, w.Code == 200, "expected error from GetLocks to be non nil")
+	Assert(t, w.Code == 200, "expected successful status code from GetLocks but got %s", w.Code)
 	body, err := ioutil.ReadAll(w.Result().Body)
 	Ok(t, err)
 	var response server.GetLocksResponse

--- a/server/server.go
+++ b/server/server.go
@@ -490,6 +490,7 @@ func (s *Server) Start() error {
 	s.Router.HandleFunc("/github-app/exchange-code", s.GithubAppController.ExchangeCode).Methods("GET")
 	s.Router.HandleFunc("/github-app/setup", s.GithubAppController.New).Methods("GET")
 	s.Router.HandleFunc("/locks", s.LocksController.DeleteLock).Methods("DELETE").Queries("id", "{id:.*}")
+	s.Router.HandleFunc("/locks", s.GetLocks).Methods("GET")
 	s.Router.HandleFunc("/lock", s.LocksController.GetLock).Methods("GET").
 		Queries(LockViewRouteIDQueryParam, fmt.Sprintf("{%s}", LockViewRouteIDQueryParam)).Name(LockViewRouteName)
 	n := negroni.New(&negroni.Recovery{
@@ -598,6 +599,24 @@ func (s *Server) Healthz(w http.ResponseWriter, _ *http.Request) {
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintf(w, "Error creating status json response: %s", err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(data) // nolint: errcheck
+}
+
+// GetLocks returns a list of PR urls to locks held by that PR
+func (s *Server) GetLocks(w http.ResponseWriter, _ *http.Request) {
+	locks, err := s.LocksController.GetLocks()
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "Error listing locks: %s", err)
+		return
+	}
+	data, err := json.Marshal(locks)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "Error creating list response: %s", err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/server/server.go
+++ b/server/server.go
@@ -490,7 +490,7 @@ func (s *Server) Start() error {
 	s.Router.HandleFunc("/github-app/exchange-code", s.GithubAppController.ExchangeCode).Methods("GET")
 	s.Router.HandleFunc("/github-app/setup", s.GithubAppController.New).Methods("GET")
 	s.Router.HandleFunc("/locks", s.LocksController.DeleteLock).Methods("DELETE").Queries("id", "{id:.*}")
-	s.Router.HandleFunc("/locks", s.GetLocks).Methods("GET")
+	s.Router.HandleFunc("/api/locks", s.LocksController.GetLocks).Methods("GET")
 	s.Router.HandleFunc("/lock", s.LocksController.GetLock).Methods("GET").
 		Queries(LockViewRouteIDQueryParam, fmt.Sprintf("{%s}", LockViewRouteIDQueryParam)).Name(LockViewRouteName)
 	n := negroni.New(&negroni.Recovery{
@@ -603,29 +603,6 @@ func (s *Server) Healthz(w http.ResponseWriter, _ *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(data) // nolint: errcheck
-}
-
-// GetLocks returns a list of PR urls to locks held by that PR
-func (s *Server) GetLocks(w http.ResponseWriter, _ *http.Request) {
-	locks, err := s.LocksController.GetLocks()
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintf(w, "Error listing locks: %s", err)
-		return
-	}
-	data, err := json.Marshal(locks)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintf(w, "Error creating list response: %s", err)
-		return
-	}
-	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(data)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintf(w, "Error writing list response: %s", err)
-		return
-	}
 }
 
 // ParseAtlantisURL parses the user-passed atlantis URL to ensure it is valid

--- a/server/server.go
+++ b/server/server.go
@@ -620,7 +620,12 @@ func (s *Server) GetLocks(w http.ResponseWriter, _ *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.Write(data) // nolint: errcheck
+	_, err = w.Write(data)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, "Error writing list response: %s", err)
+		return
+	}
 }
 
 // ParseAtlantisURL parses the user-passed atlantis URL to ensure it is valid

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -172,33 +172,25 @@ func TestHealthz(t *testing.T) {
 }
 
 func TestGetLocks(t *testing.T) {
-	t.Log("Index should render the index template successfully.")
+	t.Log("Get locks should return map of PR urls to list of locks held")
 	RegisterMockTestingT(t)
 	l := mocks.NewMockLocker()
-	// These are the locks that we expect to be rendered.
-	now := time.Now()
 	locks := map[string]models.ProjectLock{
 		"lkysow/atlantis-example/./default": {
 			Pull: models.PullRequest{
-				Num: 9,
 				URL: "https://github.com/lkysow/atlantis/example/pull/7",
 			},
 			Project: models.Project{
 				RepoFullName: "lkysow/atlantis-example",
 				Path:         ".",
 			},
-			Time:      now,
 			Workspace: "default",
 		},
 	}
 	When(l.List()).ThenReturn(locks, nil)
 	it := sMocks.NewMockTemplateWriter()
 	r := mux.NewRouter()
-	atlantisVersion := "0.3.1"
-	// Need to create a lock route since the server expects this route to exist.
 	r.NewRoute().Path("/locks")
-	u, err := url.Parse("https://example.com")
-	Ok(t, err)
 	lc := server.LocksController{
 		Logger: logging.NewNoopLogger(),
 		Locker: l,
@@ -207,8 +199,6 @@ func TestGetLocks(t *testing.T) {
 		Locker:          l,
 		IndexTemplate:   it,
 		Router:          r,
-		AtlantisVersion: atlantisVersion,
-		AtlantisURL:     u,
 		LocksController: &lc,
 	}
 	req, _ := http.NewRequest("GET", "/locks", bytes.NewBuffer(nil))


### PR DESCRIPTION
This adds an endpoint at /locks that return JSON map of pull request URLs to the IDs of the locks that are currently held by that PR.